### PR TITLE
Add Clang-Tidy check to CI workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,51 @@
+---
+# Here is an explanation for why some of the checks are disabled:
+#
+# -readability-identifier-length:
+#  : We want to enable this but this requires large cleanup efforts.
+#
+# -readability-convert-member-functions-to-static:
+#  : This wants to put 'static' in the inlined function defined outside the class definition
+#   but 'static' must be specified inside the class definition.
+
+Checks: >
+  -*,
+  readability-*,
+  -readability-avoid-const-params-in-decls,
+  -readability-magic-numbers,-warnings-as-errors,
+  -readability-isolate-declaration,
+  -readability-avoid-unconditional-preprocessor-if,
+  -readability-identifier-length,
+  -readability-convert-member-functions-to-static,
+  -readability-named-parameter,
+  bugprone-*,
+  -bugprone-signal-handler,
+  cert-*,
+  -cert-err58-cpp,
+  -cert-msc51-cpp,
+
+WarningsAsErrors: '*'
+
+# HeaderFilterRegex: ''
+
+CheckOptions:
+  - key:             readability-identifier-naming.FunctionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           'name|message|make_error_code'
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassIgnoredRegexp
+    value:           'is_error_condition_enum'
+  - key:             readability-identifier-naming.MemberCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.MemberSuffix
+    value:           _
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           UPPER_CASE
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           1
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Build clang-tidy and micm docker image
+      - name: Build clang-tidy with the docker image
         run: docker build -t clang-tidy-check -f docker/Dockerfile.clang-tidy .
 
       - name: Scan includes

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,47 @@
+
+name: Clang-Tidy
+
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    name: Run Clang-Tidy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code, generate compile commands
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Build clang-tidy and micm docker image
+        run: docker build -t clang-tidy-check -f docker/Dockerfile.clang-tidy .
+
+      - name: Scan includes
+        run: |
+          INCLUDE_FILES=$(find include -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cuh' -o -name '*.inl' \) | grep -v jit | grep -v '.inl' | grep -v '.cuh' )
+          echo "scanning include files:"
+          echo ${INCLUDE_FILES} | tr " " "\n"
+          docker run --name include-scans -e INCLUDE_FILES="${INCLUDE_FILES}" -t clang-tidy-check bash -c 'time clang-tidy -p ./build/ --config-file="./.clang-tidy" -header-filter=$(pwd)/include/.* --extra-arg "-lcudart_static" --extra-arg "-std=c++20" ${INCLUDE_FILES} -- -Iinclude/ -isystem ./build/_deps/json-src/include'
+        continue-on-error: true
+
+      # - name: Scan C++/CUDA source
+      #   run: |
+      #     SOURCE_FILES=$(find src -type f \( -name '*.cu' -o -name '*.hpp' -o -name '*.h' -o -name '*.cpp' \))
+      #     echo "scanning src files:"
+      #     echo ${SOURCE_FILES} | tr " " "\n"
+      #     docker run --name source-scans -e SOURCE_FILES="${SOURCE_FILES}" -t clang-tidy-check bash -c 'time clang-tidy -p ./build/ --config-file="./.clang-tidy" -header-filter=$(pwd)/include/.* --extra-arg "-lcudart_static" --extra-arg "-std=c++20" --extra-arg "--cuda-gpu-arch=sm_80" ${SOURCE_FILES} -- -Iinclude/ -isystem ./build/_deps/googletest-src/googletest/include -isystem ./build/_deps/json-src/include'
+      #   continue-on-error: true
+
+      - name: Scan Test files
+        run: |
+          TEST_FILES=$(find test -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cpp' -o -name '*.cuh' -o -name '*.cu' \) ! -path 'test/tutorial/*'  ! -path '**/*.cuh' ! -path '**/*jit*' )
+          echo "scanning test files:"
+          echo ${TEST_FILES} | tr " " "\n"
+          docker run --name test-scans -e TEST_FILES="${TEST_FILES}" -t clang-tidy-check bash -c 'time clang-tidy -p ./build/ --config-file="./.clang-tidy" -header-filter=$(pwd)/include/.* --extra-arg "-std=c++20" -- -Iinclude/ -isystem ./build/_deps/googletest-src/googletest/include -isystem ./build/_deps/json-src/include'
+        continue-on-error: true

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,5 +43,5 @@ jobs:
           TEST_FILES=$(find test -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.cpp' -o -name '*.cuh' -o -name '*.cu' \) ! -path 'test/tutorial/*'  ! -path '**/*.cuh' ! -path '**/*jit*' )
           echo "scanning test files:"
           echo ${TEST_FILES} | tr " " "\n"
-          docker run --name test-scans -e TEST_FILES="${TEST_FILES}" -t clang-tidy-check bash -c 'time clang-tidy -p ./build/ --config-file="./.clang-tidy" -header-filter=$(pwd)/include/.* --extra-arg "-std=c++20" -- -Iinclude/ -isystem ./build/_deps/googletest-src/googletest/include -isystem ./build/_deps/json-src/include'
+          docker run --name test-scans -e TEST_FILES="${TEST_FILES}" -t clang-tidy-check bash -c 'time clang-tidy -p ./build/ --config-file="./.clang-tidy" -header-filter=$(pwd)/include/.* --extra-arg "-std=c++20" ${TEST_FILES} -- -Iinclude/ -isystem ./build/_deps/googletest-src/googletest/include -isystem ./build/_deps/json-src/include'
         continue-on-error: true

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -11,7 +11,7 @@ RUN apt -y update \
         build-essential \
     && apt clean all
 
-RUN clang-tidy --version && nvcc --version && cmake --version
+RUN clang-tidy --version && cmake --version
 
 # copy the PR source code
 COPY . /linear_algebra_pr/

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -4,6 +4,7 @@ RUN apt -y update \
     && apt -y install \
         cmake \
         g++ \
+        git \
         make \
 #        nvidia-cuda-toolkit \
         clang \

--- a/docker/Dockerfile.clang-tidy
+++ b/docker/Dockerfile.clang-tidy
@@ -1,0 +1,28 @@
+FROM ubuntu:24.04
+
+RUN apt -y update \
+    && apt -y install \
+        cmake \
+        g++ \
+        make \
+#        nvidia-cuda-toolkit \
+        clang \
+        clang-tidy \
+        build-essential \
+    && apt clean all
+
+RUN clang-tidy --version && nvcc --version && cmake --version
+
+# copy the PR source code
+COPY . /linear_algebra_pr/
+
+# build the unit test
+RUN cd /linear_algebra_pr \
+    && cmake \
+      -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+      -D CMAKE_BUILD_TYPE=release \
+      -D ENABLE_UNIT_TESTS=ON \
+      -B./build \
+      -S.
+
+WORKDIR /linear_algebra_pr

--- a/include/test_utils.hpp
+++ b/include/test_utils.hpp
@@ -7,7 +7,7 @@
 
 // verify two vectors with a relative tolerance
 template<typename T>
-void verify(const std::vector<T>& vector_test, const std::vector<T>& vector_base, T rel_tolerance)
+void Verify(const std::vector<T>& vector_test, const std::vector<T>& vector_base, T rel_tolerance)
 {
   ASSERT_EQ(vector_test.size(), vector_base.size());
   std::size_t vector_size = vector_test.size();

--- a/test/unit/test_trid_matrix_solver.cpp
+++ b/test/unit/test_trid_matrix_solver.cpp
@@ -22,7 +22,7 @@ void testNaiveSolveDoublePrecision(const int n)
   NaiveSolve<double>(matrix, b, x);                         // call the naive tridiaonal matrix solver
   double rel_tolerance = 2e-11;                             // relative tolerance for double precision
   auto b_test = matrix.ComputeAx(x);
-  verify<double>(b_test, b, rel_tolerance);
+  Verify<double>(b_test, b, rel_tolerance);
 }
 
 void testNaiveSolveSinglePrecision(const int n)
@@ -39,7 +39,7 @@ void testNaiveSolveSinglePrecision(const int n)
   NaiveSolve<float>(matrix, b, x);                         // call the naive tridiaonal matrix solver
   float rel_tolerance = 2e-2;                              // relative tolerance for single precision
   auto b_test = matrix.ComputeAx(x);
-  verify<float>(b_test, b, rel_tolerance);
+  Verify<float>(b_test, b, rel_tolerance);
 }
 
 TEST(TridMatrixSolver, NaiveImplementationDoublePrecision)


### PR DESCRIPTION
fix #14 

Currently the Clang-Tidy will issue warnings and errors, but not physically affect the code changes. We can check details by looking at the output of Clang-Tidy action and apply the suggestions manually if desired.